### PR TITLE
Allow phploc 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "squizlabs/php_codesniffer": "^2.8",
     "sebastian/phpcpd": "^2.0|^3.0",
     "mayflower/php-codebrowser": "^1.1",
-    "phploc/phploc": "^3.0"
+    "phploc/phploc": "^3.0|^4.0"
   },
   "bin": [
     "bin/apigen.phar",


### PR DESCRIPTION
https://github.com/bearsunday/BEAR.QATools/issues/4

phploc 3.x is required sebastian/git ( https://github.com/sebastianbergmann/git )
but sebastian/git was abandoned
 