### PR TITLE
Update dependencies to ensure compatibility and remove unused package

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -1,0 +1,34 @@
+name: PHP Compatibility Check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  composer-update:
+    name: Composer Update Check (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Run composer update
+        run: composer update --no-interaction --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "php": "^7.4 || ^8.0",
         "doctrine/coding-standard": "^9 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "friendsofphp/php-cs-fixer": "^3.4",
-        "phploc/phploc": "^7.0",
         "phpmd/phpmd": "^2.11",
         "phpmetrics/phpmetrics": "^2.7",
         "phpstan/phpstan": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpmd/phpmd": "^2.11",
         "phpmetrics/phpmetrics": "^2.7",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "^9.6 || ^10.5 || ^11.3",
+        "phpunit/phpunit": "^9.6 || ^10.5 || ^11.3 || ^12.0",
         "psalm/plugin-phpunit": "^0.16 || ^0.19",
         "squizlabs/php_codesniffer": "^3.5",
         "vimeo/psalm": "^4.2 || ^5.25"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/coding-standard": "^9 || ^10.0 || ^11.0 || ^12.0",
+        "doctrine/coding-standard": "^9 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "phploc/phploc": "^7.0",
         "phpmd/phpmd": "^2.11",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpunit/phpunit": "^9.6 || ^10.5 || ^11.3 || ^12.0",
         "psalm/plugin-phpunit": "^0.16 || ^0.19",
         "squizlabs/php_codesniffer": "^3.5",
-        "vimeo/psalm": "^4.2 || ^5.25"
+        "vimeo/psalm": "^4.2 || ^5.25 || ^6.11"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
```
### Description

This pull request makes the following updates:
- **Updated `vimeo/psalm` dependency:** Added support for version `^6.11` to ensure compatibility with the latest releases while keeping older versions supported.
- **Updated `PHPUnit` requirement:** Added version `12.0` compatibility to leverage the latest updates and features.
- **Removed `phploc/phploc` dependency:** Eliminated `phploc` from `composer.json` since it is no longer needed, streamlining project dependencies.
- **Updated `doctrine/coding-standard` dependency:** Added compatibility for version `^13.0` to align with the latest coding standards.

These changes ensure the project stays compatible with the latest tooling while simplifying unnecessary dependencies.

### Checklist

- [ ] I have read the [Contributing Guidelines](https://github.com/org/repo/blob/main/CONTRIBUTING.md).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules

## Summary by Sourcery

Update composer dependencies to ensure compatibility with the latest versions of Doctrine coding standard, PHPUnit, and Psalm, and remove the unused phploc package

Build:
- Add compatibility for doctrine/coding-standard ^13.0, phpunit ^12.0, and vimeo/psalm ^6.11
- Remove unused phploc dependency