### PR TITLE
Support PHP 8.5

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,8 @@
         "phpmetrics/phpmetrics": "^2.7",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^9.6 || ^10.5 || ^11.3 || ^12.0",
-        "psalm/plugin-phpunit": "^0.16 || ^0.19",
         "squizlabs/php_codesniffer": "^3.5",
-        "vimeo/psalm": "^4.2 || ^5.25 || ^6.11"
+        "vimeo/psalm": "^4.2 || ^5.25 || ^6.11 || 6.x-dev as 6.14"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
## Summary by Sourcery

Add support for PHP 8.5 in compatibility checks and adjust static analysis dependencies accordingly.

Build:
- Relax Psalm version constraint to allow development 6.x versions aliased as 6.14.

CI:
- Extend PHP compatibility workflow matrix to run against PHP 8.5.